### PR TITLE
Fix backend Docker build context for dev requirements

### DIFF
--- a/SEIDRA-Ultimate/backend/Dockerfile
+++ b/SEIDRA-Ultimate/backend/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.11-slim AS base
-WORKDIR /app
+
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -9,10 +11,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-COPY requirements-dev.txt ./
-RUN pip install --upgrade pip && pip install -r requirements-dev.txt
+# Copie des fichiers nécessaires à l'installation des dépendances
+COPY pyproject.toml README.md ./
+COPY backend/requirements-dev.txt ./backend/requirements-dev.txt
 
-COPY . .
+RUN pip install --upgrade pip \
+    && pip install -r backend/requirements-dev.txt
+
+# Copie du code de l'application
+COPY backend ./backend
+
+WORKDIR /app/backend
 
 EXPOSE 8000
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/SEIDRA-Ultimate/deploy/README.md
+++ b/SEIDRA-Ultimate/deploy/README.md
@@ -31,7 +31,7 @@ export SEIDRA_REGISTRY="ghcr.io/<organisation>/<repo>"
 export SEIDRA_TAG="dryrun-$(date +%s)"
 
 # Construire et charger les images dans Docker
-docker buildx build backend \
+docker buildx build . \
   --file backend/Dockerfile \
   --platform linux/amd64 \
   --tag "${SEIDRA_REGISTRY}/ultimate-backend:${SEIDRA_TAG}" \

--- a/SEIDRA-Ultimate/deploy/helm/README.md
+++ b/SEIDRA-Ultimate/deploy/helm/README.md
@@ -20,7 +20,7 @@ Les commandes suivantes construisent les images backend et frontend avec les mê
 
 ```bash
 # Backend
-docker buildx build backend \
+docker buildx build . \
   --file backend/Dockerfile \
   --tag "${SEIDRA_REGISTRY}/ultimate-backend:${SEIDRA_TAG}" \
   --tag "${SEIDRA_REGISTRY}/ultimate-backend:latest" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
 
   backend:
     build:
-      context: ./SEIDRA-Ultimate/backend
-      dockerfile: Dockerfile
+      context: ./SEIDRA-Ultimate
+      dockerfile: backend/Dockerfile
     env_file:
       - .env.docker
     environment:
@@ -41,8 +41,8 @@ services:
 
   worker:
     build:
-      context: ./SEIDRA-Ultimate/backend
-      dockerfile: Dockerfile
+      context: ./SEIDRA-Ultimate
+      dockerfile: backend/Dockerfile
     command: celery -A workers.celery_app worker --loglevel=info
     env_file:
       - .env.docker
@@ -58,8 +58,8 @@ services:
 
   beat:
     build:
-      context: ./SEIDRA-Ultimate/backend
-      dockerfile: Dockerfile
+      context: ./SEIDRA-Ultimate
+      dockerfile: backend/Dockerfile
     command: celery -A workers.celery_app beat --loglevel=info
     env_file:
       - .env.docker


### PR DESCRIPTION
## Summary
- copy the project metadata before installing backend development dependencies so the editable install succeeds
- update docker-compose build contexts and deployment docs to use the repository root when building backend images

## Testing
- not run (requires Docker tooling)


------
https://chatgpt.com/codex/tasks/task_e_68d9ac93a1f88332a53a39c3939e2c82