### PR TITLE
Fix backend Dockerfile dependency copy stage

### DIFF
--- a/SEIDRA-Ultimate/backend/Dockerfile
+++ b/SEIDRA-Ultimate/backend/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Copie des fichiers nécessaires à l'installation des dépendances
-COPY pyproject.toml README.md ./
+COPY pyproject.toml ./
 COPY backend/requirements-dev.txt ./backend/requirements-dev.txt
 
 RUN pip install --upgrade pip \


### PR DESCRIPTION
## Summary
- remove the COPY directive for README.md that caused builds to fail when the file is absent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9ae214a048332bbaf1d48f2c2dfdb