### PR TITLE
Corriger l'installation editable dans le Dockerfile backend

### DIFF
--- a/SEIDRA-Ultimate/backend/Dockerfile
+++ b/SEIDRA-Ultimate/backend/Dockerfile
@@ -11,15 +11,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copie des fichiers nécessaires à l'installation des dépendances
+# Copie du code de l'application (nécessaire pour l'installation editable)
 COPY pyproject.toml ./
-COPY backend/requirements-dev.txt ./backend/requirements-dev.txt
+COPY backend ./backend
 
 RUN pip install --upgrade pip \
     && pip install -r backend/requirements-dev.txt
-
-# Copie du code de l'application
-COPY backend ./backend
 
 WORKDIR /app/backend
 


### PR DESCRIPTION
## Résumé
- copier le code backend avant l'installation des dépendances pour permettre l'installation editable

## Tests
- Aucun test automatisé n'a été exécuté

------
https://chatgpt.com/codex/tasks/task_e_68d9aec333408332885e9c21a43c9cb4