### PR TITLE
Fix backend Docker build failure caused by editable install path

### DIFF
--- a/SEIDRA-Ultimate/backend/Dockerfile
+++ b/SEIDRA-Ultimate/backend/Dockerfile
@@ -13,13 +13,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copie des fichiers nécessaires à l'installation des dépendances
 COPY pyproject.toml ./
-COPY backend/requirements-dev.txt ./backend/requirements-dev.txt
+COPY backend ./backend
 
 RUN pip install --upgrade pip \
-    && pip install -r backend/requirements-dev.txt
-
-# Copie du code de l'application
-COPY backend ./backend
+    && cd backend \
+    && pip install -r requirements-dev.txt
 
 WORKDIR /app/backend
 


### PR DESCRIPTION
## Summary
- copy the whole backend source tree before dependency installation in the backend Dockerfile
- install development dependencies from within the backend directory so the editable requirement resolves correctly

## Testing
- docker build -f SEIDRA-Ultimate/backend/Dockerfile SEIDRA-Ultimate -t seidra-backend-test *(fails: docker not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9afee2df8833298c0286700519b2e