### PR TITLE
Corriger les erreurs de lint empêchant le build frontend

### DIFF
--- a/SEIDRA-Ultimate/frontend/src/__tests__/app-e2e.test.tsx
+++ b/SEIDRA-Ultimate/frontend/src/__tests__/app-e2e.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/components/onboarding/onboarding-wizard', () => ({
     <div data-testid="onboarding" data-open={String(isOpen)}>
       {isOpen ? 'Onboarding ouvert' : 'Onboarding fermé'}
       <button onClick={onClose} type="button">
-        Fermer l'onboarding
+        Fermer l&apos;onboarding
       </button>
     </div>
   ),

--- a/SEIDRA-Ultimate/frontend/src/components/jobs/job-monitor.tsx
+++ b/SEIDRA-Ultimate/frontend/src/components/jobs/job-monitor.tsx
@@ -58,12 +58,6 @@ export function JobMonitor() {
     applyFilters({ status: undefined, persona_id: undefined, search: undefined, offset: 0 })
   }
 
-  useEffect(() => {
-    const updates = Object.values(jobUpdates)
-    if (updates.length === 0) return
-    setJobs((previous) => mergeJobUpdates(previous, updates))
-  }, [jobUpdates])
-
   return (
     <section className="space-y-6">
       <div className="rounded-2xl border border-purple-500/30 bg-black/40 p-6 text-purple-100 shadow-xl">


### PR DESCRIPTION
## Résumé
- échapper l’apostrophe dans le test de bout en bout pour respecter la règle `react/no-unescaped-entities`
- supprimer l’effet React redondant dans `JobMonitor` afin de conserver la dépendance `setJobs`

## Tests
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d9b253bac48332b989aea4518b10ae