### PR TITLE
Fix frontend Docker build when public folder missing

### DIFF
--- a/SEIDRA-Ultimate/frontend/Dockerfile
+++ b/SEIDRA-Ultimate/frontend/Dockerfile
@@ -7,6 +7,7 @@ FROM node:18-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+RUN mkdir -p public
 RUN npm run build
 
 FROM node:18-alpine AS runner


### PR DESCRIPTION
## Summary
- ensure the frontend Docker builder stage creates an empty public directory so the final image can copy it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b34e01ec8332b242134f16cb3b90