### PR TITLE
Add psycopg dependency and fix frontend lint issue

### DIFF
--- a/SEIDRA-Ultimate/frontend/src/__tests__/app-e2e.test.tsx
+++ b/SEIDRA-Ultimate/frontend/src/__tests__/app-e2e.test.tsx
@@ -41,7 +41,7 @@ vi.mock('@/components/onboarding/onboarding-wizard', () => ({
     <div data-testid="onboarding" data-open={String(isOpen)}>
       {isOpen ? 'Onboarding ouvert' : 'Onboarding fermé'}
       <button onClick={onClose} type="button">
-        Fermer l&apos;onboarding
+        Fermer l’onboarding
       </button>
     </div>
   ),
@@ -89,7 +89,7 @@ describe('Parcours bout-en-bout depuis la page d\'accueil', () => {
     const onboarding = await screen.findByTestId('onboarding')
     expect(onboarding).toHaveAttribute('data-open', 'true')
 
-    await user.click(screen.getByText("Fermer l'onboarding"))
+    await user.click(screen.getByText('Fermer l’onboarding'))
 
     await waitFor(() => {
       expect(screen.getByTestId('onboarding')).toHaveAttribute('data-open', 'false')

--- a/SEIDRA-Ultimate/pyproject.toml
+++ b/SEIDRA-Ultimate/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pillow>=10.1,<11",
     "prometheus-client>=0.18,<0.21",
     "psutil>=5.9,<6",
+    "psycopg[binary]>=3.1,<4",
     "pydantic-settings>=2.0,<3",
     "python-dotenv>=1,<2",
     "python-multipart>=0.0.6,<0.0.8",


### PR DESCRIPTION
## Summary
- add psycopg[binary] to the backend dependencies so the containers include the PostgreSQL driver
- adjust the onboarding close button label in the frontend E2E test to satisfy the React lint rule

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9b43b879c83329d43add1b17d2e03