### PR TITLE
Fix backend media directory initialization before static mount

### DIFF
--- a/SEIDRA-Ultimate/backend/main.py
+++ b/SEIDRA-Ultimate/backend/main.py
@@ -168,6 +168,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+ensure_runtime_directories(settings)
 app.mount("/media", StaticFiles(directory=settings.media_directory), name="media")
 
 app.include_router(auth_router, prefix="/api/auth", tags=["Authentication"])


### PR DESCRIPTION
## Summary
- ensure the runtime directories exist before mounting the media static files

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9b5bb82588332aab8682d4977aa6f